### PR TITLE
Put the network related configuration in an extra file

### DIFF
--- a/3-network-setup.sh
+++ b/3-network-setup.sh
@@ -1,12 +1,6 @@
 #! /bin/sh
 
-# get my IP address
-# if I'm using virtual box, my machines have two interfaces:
-# enp0s8 as host only network (only reaching from host)
-# enp0s3 as NAT interface (only reachable from extern)
-# we need the internal interface ;-)
-MYIP=`ip route | grep kernel | grep enp0s8 | cut -d " " -f 9`
-MYNAME=`hostname`
+source ./CONFIG
 
 echo "My Name:" $MYNAME
 echo "My IP:" $MYIP 

--- a/4-kubeadm-run.sh
+++ b/4-kubeadm-run.sh
@@ -6,8 +6,7 @@ POD_NETWORK_CIDR=10.42.0.0/16
 # Networks for service definitions
 SERVICE_CIDR=10.96.0.0/12
 
-HOSTNAME=`hostname`
-MYIP=`grep $HOSTNAME /etc/hosts | cut -d " " -f 1`
+source ./CONFIG
 
 # enable crio
 # systemctl enable --now crio

--- a/5-post-install.sh
+++ b/5-post-install.sh
@@ -1,9 +1,9 @@
 #! /bin/sh
 
+source ./CONFIG
+
 # Base command
 KUBECTL="kubectl --kubeconfig=/etc/kubernetes/admin.conf"
-# My hostname
-HOSTNAME=`hostname`
 
 # make master schedulable
 $KUBECTL patch nodes $(hostname) -p '{"spec":{"taints":[]}}'

--- a/CONFIG
+++ b/CONFIG
@@ -1,0 +1,7 @@
+# get my IP address
+# if I'm using virtual box, my machines have two interfaces:
+# enp0s8 as host only network (only reaching from host)
+# enp0s3 as NAT interface (only reachable from extern)
+# we need the internal interface ;-)
+MYIP=`ip route | grep kernel | grep enp0s8 | cut -d " " -f 9`
+MYNAME=`hostname`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ sudo cp /etc/kubernetes/admin.conf ~/.kube/
 sudo chown $USER ~/.kube/admin.conf
 ```
 
-Now you should put something like `export KUBECONFIG=~/.kube/admin.config` in your shell startup.
+Now you should put something like `export KUBECONFIG=~/.kube/admin.conf` in your shell startup.
 
 You can now validate your login with `kubectl config get-contexts`
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Follow the work in directory [raspbian](raspbian/)
 - Base installation of CentOS 7 minimal
 - After the base installation I made a pair of very small shell scripts to aid the install:
 
+1. [CONFIG] -> open it to configure your interface/IP address and hostname
 1. [1-repo.sh](1-repo.sh) -> add kubernetes repo and install packages
 1. [2-system-setup.sh](2-system-setup.sh) -> disable swap, disable selinux
 1. [3-network-setup.sh](3-network-setup.sh) -> customize firewalld, setting hostname


### PR DESCRIPTION
The installation of gubernat to my virtualbox didn't work because of the hostname `localhost.localdomain` and the missing second interface `enp0s8`.

To fix this, I overwrote the respective variable definitions. As they are in more than one file, I decided to move this into an extra configuration file called `CONFIG`.