### PR TITLE
Improve Upgrade Process

### DIFF
--- a/cluster-template/inventory.yaml
+++ b/cluster-template/inventory.yaml
@@ -67,3 +67,5 @@ all:
     # ansible user
     ansible_user: root
     ansible_ssh_private_key_file: "./config:{{ clustername }}/root-ssh-key"
+    # Upgrade the OS version when Upgrading K8s
+    upgrade_os: false

--- a/roles/common/templates/cri-o.repo.j2
+++ b/roles/common/templates/cri-o.repo.j2
@@ -4,9 +4,9 @@ name=CRI-O
 baseurl={{ crio_pkg_mirror }}/cri-o-{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}
 gpgcheck=0
 {% else %}
-baseurl=https://pkgs.k8s.io/addons:/cri-o:/stable:/v{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}/rpm/
+baseurl=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}/rpm/
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/addons:/cri-o:/stable:/v{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}/rpm/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}/rpm/repodata/repomd.xml.key
 {% endif %}
 enabled=1
 exclude=cri-o

--- a/roles/upgrade_cluster/tasks/common_after.yml
+++ b/roles/upgrade_cluster/tasks/common_after.yml
@@ -23,6 +23,24 @@
     state: restarted
     name: cri-o
 
+- name: Upgrade OS
+  block:
+  - name: Bring system to newest software level
+    ansible.builtin.dnf:
+      name: "*"
+      state: latest
+
+  - name: Check if a reboot is required
+    ansible.builtin.command: needs-restarting -r
+    register: reboot_required
+    failed_when: false
+
+  - name: Reboot the server if required
+    ansible.builtin.reboot:
+      msg: "Rebooting after updates"
+    when: reboot_required.rc != 0
+  when: upgrade_os is true
+
 - name: Wait for sure until node is ready again (3 minutes)
   ansible.builtin.pause:
     minutes: 3

--- a/roles/upgrade_cluster/tasks/common_after.yml
+++ b/roles/upgrade_cluster/tasks/common_after.yml
@@ -12,16 +12,19 @@
     - cri-o-{{ crio_version }}
     disable_excludes: all
     state: present
+  register: k8s_dnf_update
 
 - name: Restart kubelet
   ansible.builtin.systemd:
     state: restarted
     name: kubelet
+  when: k8s_dnf_update is changed 
 
 - name: Restart cri-o
   ansible.builtin.systemd:
     state: restarted
     name: cri-o
+  when: k8s_dnf_update is changed 
 
 - name: Upgrade OS
   block:

--- a/roles/upgrade_cluster/tasks/common_before.yml
+++ b/roles/upgrade_cluster/tasks/common_before.yml
@@ -24,6 +24,7 @@
       - tar 
       - git
       - kubernetes-cni
+      - yum-utils
     disable_excludes: all
     state: latest
 

--- a/roles/upgrade_cluster/templates/cri-o.repo.j2
+++ b/roles/upgrade_cluster/templates/cri-o.repo.j2
@@ -4,9 +4,9 @@ name=CRI-O
 baseurl={{ crio_pkg_mirror }}/cri-o-{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}
 gpgcheck=0
 {% else %}
-baseurl=https://pkgs.k8s.io/addons:/cri-o:/stable:/v{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}/rpm/
+baseurl=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}/rpm/
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/addons:/cri-o:/stable:/v{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}/rpm/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v{{ crio_version | regex_replace('^(\\d+\\.\\d+)\\.\\d+$', '\\1') }}/rpm/repodata/repomd.xml.key
 {% endif %}
 enabled=1
 exclude=cri-o


### PR DESCRIPTION
According to https://cri-o.io/#important-notice the Cri-o repo is now hosted at opensuse 
and also add the possibility, when updating K8s to update the OS itself too.

And I was able to upgrade a single node cluster from 1.31 to 1.33 without problems

